### PR TITLE
next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## V0.11.3
+
+- Raise error if `autoinit` is used with `__init__` method defined.
+- Avoid applying `copy.copy` `jax.Array` during flatten/unflatten or `AtIndexer` operations.
+- Add `at` as an alias for `AtIndexer` for shorter syntax.
+- Deprecate `AtIndexer.__call__` in favor of `value_and_tree` to apply function in a functional manner by copying the input argument.
+
+```python
+import sepes as sp
+class Counter(sp.TreeClass):
+    def __init__(self, count: int):
+        self.count = count
+    def increment(self, value):
+        self.count += value
+        return self.count
+counter = Counter(0)
+# the function follow jax.value_and_grad semantics where the tree is the
+# copied mutated input argument, if the function mutates the input arguments
+sp.value_and_tree(lambda C: C.increment(1))(counter)
+# (1, Counter(count=1))
+```
+
+- Updated docstrings. e.g. How to construct flops counter in `tree_summary` using `jax.jit`
+
 ## V0.11.2
 
 - No freezing rule for `jax.Tracer` in `sp.freeze`

--- a/docs/API/core.rst
+++ b/docs/API/core.rst
@@ -7,8 +7,8 @@
 .. autoclass:: TreeClass 
     :members:
         at
-
 .. autoclass:: Partial
+.. autoclass:: partial
 .. autoclass:: AtIndexer
     :members:
         get,
@@ -17,15 +17,15 @@
         scan,
         reduce,
         pluck,
-        __call__
-        
+
+.. autoclass:: at
 .. autoclass:: BaseKey
     :members:
         __eq__
-
 .. autofunction:: autoinit
 .. autofunction:: leafwise
 .. autofunction:: field
 .. autofunction:: fields
 .. autofunction:: bcmap
 .. autofunction:: is_tree_equal
+.. autofunction:: value_and_tree

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ ignore = [
   "N813",
   "D105",
   "C901",
-  "B102",
 ]
 
 [tool.ruff.pydocstyle]

--- a/sepes/__init__.py
+++ b/sepes/__init__.py
@@ -15,7 +15,7 @@
 from sepes._src.backend import backend_context
 from sepes._src.code_build import autoinit, field, fields
 from sepes._src.tree_base import TreeClass
-from sepes._src.tree_index import AtIndexer, BaseKey
+from sepes._src.tree_index import AtIndexer, BaseKey, at
 from sepes._src.tree_mask import (
     freeze,
     is_frozen,
@@ -32,7 +32,14 @@ from sepes._src.tree_pprint import (
     tree_str,
     tree_summary,
 )
-from sepes._src.tree_util import Partial, bcmap, is_tree_equal, leafwise
+from sepes._src.tree_util import (
+    Partial,
+    bcmap,
+    is_tree_equal,
+    leafwise,
+    partial,
+    value_and_tree,
+)
 
 __all__ = (
     # general utils
@@ -57,16 +64,19 @@ __all__ = (
     "tree_mask",
     # indexing utils
     "AtIndexer",
+    "at",
     "BaseKey",
     # tree utils
     "bcmap",
     "Partial",
+    "partial",
     "leafwise",
+    "value_and_tree",
     # backend utils
     "backend_context",
 )
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"
 
 AtIndexer.__module__ = "sepes"
 TreeClass.__module__ = "sepes"

--- a/sepes/_src/tree_mask.py
+++ b/sepes/_src/tree_mask.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, NamedTuple, TypeVar, Union
 
 import sepes
 import sepes._src.backend.arraylib as arraylib
+from sepes._src.backend import is_package_avaiable
 from sepes._src.tree_pprint import tree_repr, tree_str, tree_summary
 from sepes._src.tree_util import Static, is_tree_equal, tree_copy, tree_hash
 
@@ -415,8 +416,6 @@ def tree_unmask(tree: T, mask: MaskType = lambda _: True):
     """
     return _tree_mask_map(tree, mask=mask, func=unfreeze, is_leaf=is_frozen)
 
-
-from sepes._src.backend import is_package_avaiable
 
 if is_package_avaiable("jax"):
     import jax

--- a/sepes/_src/tree_util.py
+++ b/sepes/_src/tree_util.py
@@ -619,16 +619,13 @@ def value_and_tree(func, argnums: int | Sequence[int] = 0):
         (args, kwargs) = tree_copy((args, kwargs))
         # and edit the node/record to make it mutable (if there is a rule for it)
         treelib.tree_map(lambda _: _, (args, kwargs), is_leaf=mutate_is_leaf)
-        trees = [a if i in argnums else None for i, a in enumerate(args)]
-        # call the function on the copies
-        args = [r if i in argnums else l for i, (l, r) in enumerate(zip(args, trees))]
         output = func(*args, **kwargs)
         # traverse each node in the tree depth-first manner
         # to undo the mutation (if there is a rule for it)
         treelib.tree_map(lambda _: _, (args, kwargs), is_leaf=immutate_is_leaf)
-        trees = [a for i, a in enumerate(args) if i in argnums]
-        trees = trees[0] if is_int_argnum else tuple(trees)
-        return output, trees
+        out_args = tuple(a for i, a in enumerate(args) if i in argnums)
+        out_args = out_args[0] if is_int_argnum else out_args
+        return output, out_args
 
     return stateless_func
 


### PR DESCRIPTION
## V0.11.3

- Raise error if `autoinit` is used with `__init__` method defined.
- Avoid applying `copy.copy` `jax.Array` during flatten/unflatten or `AtIndexer` operations.
- Add `at` as an alias for `AtIndexer` for shorter syntax.
- Deprecate `AtIndexer.__call__` in favor of `value_and_tree` to apply function in a functional manner by copying the input argument.

```python
import sepes as sp
class Counter(sp.TreeClass):
    def __init__(self, count: int):
        self.count = count
    def increment(self, value):
        self.count += value
        return self.count
counter = Counter(0)
# the function follow jax.value_and_grad semantics where the tree is the
# copied mutated input argument, if the function mutates the input arguments
sp.value_and_tree(lambda C: C.increment(1))(counter)
# (1, Counter(count=1))
```

- Updated docstrings. e.g. How to construct flops counter in `tree_summary` using `jax.jit`