### PR TITLE
bcmap argnum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## V0.11.4
 
+- Add an option to select which argument to broadcast to in `bcmap`
+
+    ```python
+    import sepes as sp 
+    def func(x, y):
+        return x + y
+    # broadcast x to y structure
+    # this effectively converts 1 -> [1,1,1]
+    sp.bcmap(func, broadcast_to="y")(x=1, y=[2,3,4]) # [3,4,5]
+    # broadcast x to y structure (argnum=1)
+    sp.bcmap(func, broadcast_to=1)(1, [2,3,4]) # [3,4,5]
+    ```
+
 - Add sharding info in `tree_summary`, `G` for global, `S` for sharded shape.
   
     ```python
@@ -25,10 +38,10 @@
     └────┴───────────┴─────┴───────┘
     ```
 
-- Reduce the API and remove:
-  -  `tree_graph` (for graphviz)
-  -  `tree_mermaid` (mermaidjs)
-  -  `Partial/partial`
+- Reduce the API footprint by removing:
+  -  `tree_graph` (for graphviz visualization)
+  -  `tree_mermaid` (mermaidjs visualization)
+  -  `Partial/partial` -> Use `jax.tree_util.Partial` instead.
   -  `is_tree_equal` -> Use `bcmap(numpy.testing.assert_*)(pytree1, pytree2)` instead.
   -  `freeze`  -> Use `ft.partial(tree_mask, lambda _: True)` instead.
   -  `unfreeze` -> Use `tree_unmask` instead.

--- a/sepes/_src/tree_mask.py
+++ b/sepes/_src/tree_mask.py
@@ -38,11 +38,7 @@ class _MaskedError(NamedTuple):
             f"Cannot apply `{self.opname}` operation to a frozen object "
             f"{', '.join(map(str, a))} "
             f"{', '.join(k + '=' + str(v) for k, v in k.items())}.\n"
-            "Unmask the object first by unmasking the frozen mask:\n"
-            "Example:\n"
-            ">>> import jax\n"
-            ">>> import sepes as sp\n"
-            ">>> tree = sp.tree_unmask(tree)"
+            "Unmask the object first using `tree_unmask`"
         )
 
 
@@ -86,7 +82,8 @@ class _MaskBase(Static):
     __and__ = __rand__ = __iand__ = _MaskedError("and")
     __xor__ = __rxor__ = __ixor__ = _MaskedError("")
     __or__ = __ror__ = __ior__ = _MaskedError("or")
-    __neg__ = __pos__ = __abs__ = __invert__ = _MaskedError("unary operation")
+    __neg__ = __pos__ = __abs__ = __invert__ = _MaskedError("unary")
+    __lt__ = __le__ = __gt__ = __ge__ = _MaskedError("comparison")
     __call__ = _MaskedError("__call__")
 
 
@@ -227,7 +224,7 @@ def _(_: float | complex) -> bool:
 
 def _tree_mask_map(
     tree: T,
-    cond: MaskType,
+    cond: Callable[[Any], bool],
     func: type | Callable[[Any], Any],
     *,
     is_leaf: Callable[[Any], None] | None = None,

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -174,3 +174,17 @@ def test_bcmap(tree, expected):
 def test_math_operations_errors():
     with pytest.raises(TypeError):
         tree1 + "s"
+
+
+def test_bcmap_int_argnum_broadcast_to():
+    def func(x, y):
+        return x + y
+
+    assert bcmap(func, broadcast_to=1)(1, [2, 3, 4]) == [3, 4, 5]
+
+
+def test_bcmap_key_argnum_broadcast_to():
+    def func(x, y):
+        return x + y
+
+    assert bcmap(func, broadcast_to="y")(x=1, y=[2, 3, 4]) == [3, 4, 5]


### PR DESCRIPTION
- Add an option to select which argument to broadcast to in `bcmap`

    ```python
    import sepes as sp 
    def func(x, y):
        return x + y
    # broadcast x to y structure
    # this effectively converts 1 -> [1,1,1]
    sp.bcmap(func, broadcast_to="y")(x=1, y=[2,3,4]) # [3,4,5]
    # broadcast x to y structure (argnum=1)
    sp.bcmap(func, broadcast_to=1)(1, [2,3,4]) # [3,4,5]
    ```
