### PR TITLE
Remove distinction between regex and string match key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,6 @@
   -  `freeze`  -> Use `ft.partial(tree_mask, lambda _: True)` instead.
   -  `unfreeze` -> Use `tree_unmask` instead.
 
--  Implement `__format__` for `TreeClass` for shorter syntax representation:
-   -  `f"{tree:3r}"` is tree **r**epr of depth = 3
-   -  `f"{tree:3s}"` is tree **s**tr of depth = 3
-   - `f"{tree:3d}"` is tree **d**iagram of depth = 3
-   -  `f"{tree:3t}`" is tree summary of depth = 3
-
 - `tree_{mask,unmask}` now accepts only callable `cond` argument.
 - Rename `is_frozen` to `is_masked`
   - frozen could mean non-trainable array, however the masking is not only for arrays but also for other types that will be hidden from jax transformations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@
 
 - `tree_{mask,unmask}` now accepts only callable `cond` argument.
 - Rename `is_frozen` to `is_masked`
-  - frozen could mean non-trainable array, however the masking is not only for arrays but also for other types that will be hidden from jax transformations.
+  - frozen could mean non-trainable array, however the masking is not only for arrays but also for other types that will be hidden across jax transformations.
+- Remove `re.compile(pattern)` to match `re.Pattern` in `where` argument in `AtIndexer`, instead use string `pattern` directly.
 
 ## V0.11.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Reduce the API and remove:
   -  `tree_graph` (for graphviz)
   -  `tree_mermaid` (mermaidjs)
-  -  `Partial/partial`
+  -  `Partial/partial` -> Use `jax.tree_util.partial` instead.
   -  `is_tree_equal` -> Use `bcmap(numpy.testing.assert_*)(pytree1, pytree2)` instead.
   -  `freeze`  -> Use `ft.partial(tree_mask, lambda _: True)` instead.
   -  `unfreeze` -> Use `tree_unmask` instead.

--- a/docs/API/core.rst
+++ b/docs/API/core.rst
@@ -7,7 +7,7 @@
 .. autoclass:: TreeClass 
     :members:
         at
-.. autoclass:: AtIndexer
+.. autoclass:: at
     :members:
         get,
         set,
@@ -16,10 +16,7 @@
         reduce,
         pluck,
 
-.. autoclass:: at
-.. autoclass:: BaseKey
-    :members:
-        __eq__
+.. autoclass:: AtIndexer
 .. autofunction:: autoinit
 .. autofunction:: leafwise
 .. autofunction:: field

--- a/sepes/__init__.py
+++ b/sepes/__init__.py
@@ -15,7 +15,7 @@
 from sepes._src.backend import backend_context
 from sepes._src.code_build import autoinit, field, fields
 from sepes._src.tree_base import TreeClass
-from sepes._src.tree_index import AtIndexer, BaseKey, at
+from sepes._src.tree_index import AtIndexer, at
 from sepes._src.tree_mask import (
     is_masked,
     is_nondiff,
@@ -53,7 +53,6 @@ __all__ = (
     # indexing utils
     "AtIndexer",
     "at",
-    "BaseKey",
     # tree utils
     "bcmap",
     "leafwise",

--- a/sepes/_src/tree_base.py
+++ b/sepes/_src/tree_base.py
@@ -270,8 +270,6 @@ class TreeClass(metaclass=TreeClassMeta):
             - ``int`` for positional indexing for sequences.
             - ``...`` to select all leaves.
             - a boolean mask of the same structure as the tree
-            - ``re.Pattern`` to index all keys matching a regex pattern.
-            - an instance of ``BaseKey`` with custom logic to index a pytree.
             - a tuple of the above types to index multiple keys at same level.
 
         Example:

--- a/sepes/_src/tree_mask.py
+++ b/sepes/_src/tree_mask.py
@@ -38,11 +38,7 @@ class _MaskedError(NamedTuple):
             f"Cannot apply `{self.opname}` operation to a frozen object "
             f"{', '.join(map(str, a))} "
             f"{', '.join(k + '=' + str(v) for k, v in k.items())}.\n"
-            "Unmask the object first by unmasking the frozen mask:\n"
-            "Example:\n"
-            ">>> import jax\n"
-            ">>> import sepes as sp\n"
-            ">>> tree = sp.tree_unmask(tree)"
+            "Unmask the object first using `tree_unmask`"
         )
 
 
@@ -86,7 +82,8 @@ class _MaskBase(Static):
     __and__ = __rand__ = __iand__ = _MaskedError("and")
     __xor__ = __rxor__ = __ixor__ = _MaskedError("")
     __or__ = __ror__ = __ior__ = _MaskedError("or")
-    __neg__ = __pos__ = __abs__ = __invert__ = _MaskedError("unary operation")
+    __neg__ = __pos__ = __abs__ = __invert__ = _MaskedError("unary")
+    __lt__ = __le__ = __gt__ = __ge__ = _MaskedError("comparison")
     __call__ = _MaskedError("__call__")
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -14,7 +14,6 @@
 
 
 import os
-import re
 from collections import namedtuple
 from typing import NamedTuple
 
@@ -23,7 +22,7 @@ import pytest
 from sepes._src.backend import arraylib, backend, treelib
 from sepes._src.code_build import autoinit
 from sepes._src.tree_base import TreeClass, _mutable_instance_registry
-from sepes._src.tree_index import AtIndexer, BaseKey
+from sepes._src.tree_index import AtIndexer, BaseMatchKey
 from sepes._src.tree_util import is_tree_equal, leafwise, value_and_tree
 
 test_arraylib = os.environ.get("SEPES_TEST_ARRAYLIB", "numpy")
@@ -102,9 +101,9 @@ _X = 1_000
         [tree7, dict(a=None, b=[2, None], c=None), ("b", 0)],
         [tree8, dict(a=None, b=ClassSubTree(c=2, d=None), e=None), ("b", 0)],
         # by regex
-        [tree1, dict(a=None, b=dict(c=2, d=None), e=None), ("b", re.compile("c"))],
-        [tree2, ClassTree(None, dict(c=2, d=None), None), ("b", re.compile("c"))],
-        [tree3, ClassTree(None, ClassSubTree(2, None), None), ("b", re.compile("c"))],
+        [tree1, dict(a=None, b=dict(c=2, d=None), e=None), ("b", ("c"))],
+        [tree2, ClassTree(None, dict(c=2, d=None), None), ("b", ("c"))],
+        [tree3, ClassTree(None, ClassSubTree(2, None), None), ("b", ("c"))],
         # by ellipsis
         [tree1, tree1, (...,)],
         [tree2, tree2, (...,)],
@@ -171,9 +170,9 @@ def test_array_indexer_get(tree, expected, where):
         [tree7, dict(a=1, b=[2, _X], c=4), ("b", 1), _X],
         [tree8, dict(a=1, b=ClassSubTree(c=2, d=_X), e=4), ("b", 1), _X],
         # by regex
-        [tree1, dict(a=1, b=dict(c=_X, d=3), e=4), ("b", re.compile("c")), _X],
-        [tree2, ClassTree(1, dict(c=_X, d=3), 4), ("b", re.compile("c")), _X],
-        [tree3, ClassTree(1, ClassSubTree(_X, 3), 4), ("b", re.compile("c")), _X],
+        [tree1, dict(a=1, b=dict(c=_X, d=3), e=4), ("b", ("c")), _X],
+        [tree2, ClassTree(1, dict(c=_X, d=3), 4), ("b", ("c")), _X],
+        [tree3, ClassTree(1, ClassSubTree(_X, 3), 4), ("b", ("c")), _X],
         # by ellipsis
         [
             tree1,
@@ -213,9 +212,9 @@ def test_indexer_set(tree, expected, where, set_value):
         [tree7, dict(a=1, b=[2, _X], c=4), ("b", 1), _X],
         [tree8, dict(a=1, b=ClassSubTree(c=2, d=_X), e=4), ("b", 1), _X],
         # by regex
-        [tree1, dict(a=1, b=dict(c=_X, d=3), e=4), ("b", re.compile("c")), _X],
-        [tree2, ClassTree(1, dict(c=_X, d=3), 4), ("b", re.compile("c")), _X],
-        [tree3, ClassTree(1, ClassSubTree(_X, 3), 4), ("b", re.compile("c")), _X],
+        [tree1, dict(a=1, b=dict(c=_X, d=3), e=4), ("b", ("c")), _X],
+        [tree2, ClassTree(1, dict(c=_X, d=3), 4), ("b", ("c")), _X],
+        [tree3, ClassTree(1, ClassSubTree(_X, 3), 4), ("b", ("c")), _X],
         # by ellipsis
         [
             tree1,
@@ -253,9 +252,9 @@ def test_array_indexer_set(tree, expected, where, set_value):
         [tree7, dict(a=1, b=[2, _X], c=4), ("b", 1)],
         [tree8, dict(a=1, b=ClassSubTree(c=2, d=_X), e=4), ("b", 1)],
         # by regex
-        [tree1, dict(a=1, b=dict(c=_X, d=3), e=4), ("b", re.compile("c"))],
-        [tree2, ClassTree(1, dict(c=_X, d=3), 4), ("b", re.compile("c"))],
-        [tree3, ClassTree(1, ClassSubTree(_X, 3), 4), ("b", re.compile("c"))],
+        [tree1, dict(a=1, b=dict(c=_X, d=3), e=4), ("b", ("c"))],
+        [tree2, ClassTree(1, dict(c=_X, d=3), 4), ("b", ("c"))],
+        [tree3, ClassTree(1, ClassSubTree(_X, 3), 4), ("b", ("c"))],
         # by ellipsis
         [tree1, dict(a=_X, b=dict(c=_X, d=_X), e=_X), (...,)],
         [tree2, ClassTree(_X, dict(c=_X, d=_X), _X), (...,)],
@@ -292,9 +291,9 @@ def test_indexer_apply(tree, expected, where):
         [tree7, dict(a=1, b=[2, _X], c=4), ("b", 1)],
         [tree8, dict(a=1, b=ClassSubTree(c=2, d=_X), e=4), ("b", 1)],
         # by regex
-        [tree1, dict(a=1, b=dict(c=_X, d=3), e=4), ("b", re.compile("c"))],
-        [tree2, ClassTree(1, dict(c=_X, d=3), 4), ("b", re.compile("c"))],
-        [tree3, ClassTree(1, ClassSubTree(_X, 3), 4), ("b", re.compile("c"))],
+        [tree1, dict(a=1, b=dict(c=_X, d=3), e=4), ("b", ("c"))],
+        [tree2, ClassTree(1, dict(c=_X, d=3), 4), ("b", ("c"))],
+        [tree3, ClassTree(1, ClassSubTree(_X, 3), 4), ("b", ("c"))],
         # by ellipsis
         [tree1, dict(a=_X, b=dict(c=_X, d=_X), e=_X), (...,)],
         [tree2, ClassTree(_X, dict(c=_X, d=_X), _X), (...,)],
@@ -328,9 +327,9 @@ def test_array_indexer_apply(tree, expected, where):
         # mixed
         [tree7, 5, ("b", (0, 1))],
         # by regex
-        [tree1, 5, ("b", re.compile("c|d"))],
-        [tree2, 5, ("b", re.compile("c|d"))],
-        [tree3, 5, ("b", re.compile("c|d"))],
+        [tree1, 5, ("b", ("c|d"))],
+        [tree2, 5, ("b", ("c|d"))],
+        [tree3, 5, ("b", ("c|d"))],
         # by ellipsis
         [tree1, 1 + 2 + 3 + 4, (...,)],
         [tree2, 1 + 2 + 3 + 4, (...,)],
@@ -363,9 +362,9 @@ def test_indexer_reduce(tree, expected, where):
         # mixed
         [tree7, 5, ("b", (0, 1))],
         # by regex
-        [tree1, 5, ("b", re.compile("c|d"))],
-        [tree2, 5, ("b", re.compile("c|d"))],
-        [tree3, 5, ("b", re.compile("c|d"))],
+        [tree1, 5, ("b", ("c|d"))],
+        [tree2, 5, ("b", ("c|d"))],
+        [tree3, 5, ("b", ("c|d"))],
         # by ellipsis
         [tree1, 1 + 2 + 3 + 4, (...,)],
         [tree2, 1 + 2 + 3 + 4, (...,)],
@@ -399,9 +398,9 @@ def test_array_indexer_reduce(tree, expected, where):
         [tree7, (dict(a=1, b=[2, 5], c=4), 3), ("b", (0, 1))],
         # [tree8, (dict(a=1, b=ClassSubTree(c=2, d=5), e=4), 3), ("b", (0, 1))],
         # by regex
-        [tree1, (dict(a=1, b=dict(c=2, d=5), e=4), 3), ("b", re.compile("c|d"))],
-        [tree2, (ClassTree(1, dict(c=2, d=5), 4), 3), ("b", re.compile("c|d"))],
-        [tree3, (ClassTree(1, ClassSubTree(2, 5), 4), 3), ("b", re.compile("c|d"))],
+        [tree1, (dict(a=1, b=dict(c=2, d=5), e=4), 3), ("b", ("c|d"))],
+        [tree2, (ClassTree(1, dict(c=2, d=5), 4), 3), ("b", ("c|d"))],
+        [tree3, (ClassTree(1, ClassSubTree(2, 5), 4), 3), ("b", ("c|d"))],
     ],
 )
 def test_indexer_scan(tree, expected, where):
@@ -554,7 +553,7 @@ def test_custom_key_optreee():
 
     tree = Tree(1, 2)
 
-    class MatchNameType(BaseKey):
+    class MatchNameType(BaseMatchKey):
         def __init__(self, name, type):
             self.name = name
             self.type = type
@@ -575,9 +574,9 @@ def test_repr_str():
 
     t = Tree()
 
-    assert repr(t.at["a"]) == "AtIndexer(tree=Tree(a=1, b=2), where=['a'])"
-    assert str(t.at["a"]) == "AtIndexer(tree=Tree(a=1, b=2), where=['a'])"
-    assert repr(t.at[...]) == "AtIndexer(tree=Tree(a=1, b=2), where=[Ellipsis])"
+    assert repr(t.at["a"]) == "at(tree=Tree(a=1, b=2), where=['a'])"
+    assert str(t.at["a"]) == "at(tree=Tree(a=1, b=2), where=['a'])"
+    assert repr(t.at[...]) == "at(tree=Tree(a=1, b=2), where=[Ellipsis])"
 
 
 def test_compat_mask():


### PR DESCRIPTION
```python

import sepes as sp

params = {
    "a_1": 1,
    "a_2": 2,
    "c": 3,
}

# new way: use regex pattern directly
sp.at(params)["a_.*"].set(10) # {'a_1': 10, 'a_2': 10, 'c': 3}

# old deprecated way: use re.compile + pattern
import re
sp.at(params)[re.compile("a_.*")].set(10) # {'a_1': 10, 'a_2': 10, 'c': 3}

```

This change is motivated by [serket](https://github.com/ASEM000/serket/issues/100), [keras](https://keras.io/guides/distribution/), and recently [grok](https://github.com/xai-org/grok-1/blob/7050ed204b8206bb8645c7b7bbef7252f79561b0/model.py#L112)
